### PR TITLE
range_too_big

### DIFF
--- a/blocks.go
+++ b/blocks.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+const BlockMaxCount = 10000
+
 type BlockIdxs struct {
 	StartHeight  int64
 	EndHeight    int64
@@ -23,6 +25,9 @@ func GetBlockIdxs(startHeight int64, arCli *goar.Client) (*BlockIdxs, error) {
 		return nil, err
 	}
 	endHeight := info.Height
+	if endHeight-startHeight >= BlockMaxCount {
+		endHeight = startHeight + BlockMaxCount - 1
+	}
 	// get block hash_list from trust node
 	spiltList, err := arCli.GetBlockHashList(int(startHeight), int(endHeight))
 	if err != nil {


### PR DESCRIPTION
- error msg:

    msg=pNode.GetBlockHashList() module=syncer err="get block hash list failed"

- triger function:

   blocks.go: GetBlockIdxs
- root cause:

    when request https://arweave.net/hash_list/800000/1000000
    response:
    ```
    {
    max_range_size: 10000,
    error: "range_too_big"
    }
    ```